### PR TITLE
Fix Click the Target styles

### DIFF
--- a/src/components/games/click-the-target/Game.tsx
+++ b/src/components/games/click-the-target/Game.tsx
@@ -211,7 +211,7 @@ const Game = ({setStarted}: GameProps) => {
                                 left: `${target.position.x}px`,
                                 top: `${target.position.y}px`,
                                 position: "absolute",
-                                height: 'calc(100dvh - 7em', overflow: 'auto'
+                                height: 'calc(100dvh - 7em)', overflow: 'auto'
                             }}
                         >
                             <Target

--- a/src/pages/game/games/ClickTheTarget.tsx
+++ b/src/pages/game/games/ClickTheTarget.tsx
@@ -8,7 +8,7 @@ const ClickTheTarget = () => {
     const [started, setStarted] = React.useState<boolean>(false);
 
     return (
-        <div style={{height: 'calc(100dvh - 6em', overflow: 'auto'}}>
+        <div style={{height: 'calc(100dvh - 6em)', overflow: 'auto'}}>
             {!started && <div className="flex flex-row w-full justify-between">
                 <p className="p-4 font-bold text-center">Click the target as many times as you can in the given
                     time!</p>


### PR DESCRIPTION
## Summary
- close CSS calc parentheses for Click the Target pages

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68417e035164832b9371c24232cd6b8b