### PR TITLE
Fix util function camelCase typo

### DIFF
--- a/src/components/generator/FormDetail.tsx
+++ b/src/components/generator/FormDetail.tsx
@@ -6,7 +6,7 @@ import SelectInput from "./inputs/SelectInput";
 import DateInput from "./inputs/DateInput";
 import FormEditor from "./FormEditor";
 import FormPreview from "./FormPreview";
-import {formatFieldToUpperCaseAndBreakCammelCase} from "../util";
+import {formatFieldToUpperCaseAndBreakCamelCase} from "../util";
 import InputField from "./inputs/InputField";
 import {formDb} from "../../assets/formDb";
 import CollapsibleSection from "../common/CollapsableSection";
@@ -79,7 +79,7 @@ const FormDetail: React.FC<FormDetailProps> = ({id}) => {
                 valid = false;
                 setErrors((prevErrors) => ({
                     ...prevErrors,
-                    [field.name]: `${formatFieldToUpperCaseAndBreakCammelCase(
+                    [field.name]: `${formatFieldToUpperCaseAndBreakCamelCase(
                         field.name
                     )} is required`,
                 }));

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -20,7 +20,7 @@ export const getRandomNumber = (min: number, max: number): number => {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
-export const formatFieldToUpperCaseAndBreakCammelCase = (field: string) => {
+export const formatFieldToUpperCaseAndBreakCamelCase = (field: string) => {
     return field
         .replace(/([A-Z])/g, " $1")
         .replace(/^./, (str) => str.toUpperCase());


### PR DESCRIPTION
## Summary
- rename `formatFieldToUpperCaseAndBreakCammelCase` to `formatFieldToUpperCaseAndBreakCamelCase`
- update imports and usages

## Testing
- `yarn build`
- `yarn test --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68417e005d14832b824cea19b9b19c49