### PR TITLE
Fix dark mode modal text

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "build-production": "tsc && vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest watch",
     "test:coverage": "vitest run --coverage"
   },

--- a/src/components/common/CommonDialog.tsx
+++ b/src/components/common/CommonDialog.tsx
@@ -34,6 +34,7 @@ const CommonDialog: React.FC<CommonDialogProps> = ({
                 className={
                     `relative w-full max-w-3xl max-h-[90vh] overflow-y-auto
           bg-white dark:bg-gray-900 shadow-2xl
+          text-gray-900 dark:text-white
           transform transition-all duration-200 ease-out
           scale-100 opacity-100
           p-4 m-4`}


### PR DESCRIPTION
## Summary
- ensure text remains visible in CommonDialog when using dark theme
- run vitest in non-watch mode so tests pass in CI

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841c1d6f858832b8dc9b428b70be6c8