### PR TITLE
Add dynamic charts dashboard

### DIFF
--- a/src/components/quote/DynamicCharts.tsx
+++ b/src/components/quote/DynamicCharts.tsx
@@ -1,0 +1,96 @@
+import React, {useState} from "react";
+import DepthChart from "./DepthChartComponent";
+import PriceHistoryChart from "./PriceHistoryChart";
+import VolumeHistoryChart from "./VolumeHistoryChart";
+import MovingAverageChart from "./MovingAverageChart";
+import PriceVolumeChart from "./PriceVolumeChart";
+import {availableSymbols, FinnhubQuote} from "./QuoteComponent";
+import {FinnhubTrade} from "./types";
+
+interface DynamicChartsProps {
+    priceHistory: { [symbol: string]: { t: number; p: number }[] };
+    volumeHistory: { [symbol: string]: { t: number; v: number }[] };
+    orderBooks: { [symbol: string]: FinnhubTrade[] };
+    quotes: { [symbol: string]: { quote: FinnhubQuote } };
+    isDarkTheme: boolean;
+    initialSymbol?: string;
+}
+
+const chartOptions = [
+    "Price History",
+    "Volume History",
+    "Depth Chart",
+    "Moving Average",
+    "Price & Volume",
+] as const;
+type ChartType = typeof chartOptions[number];
+
+const DynamicCharts: React.FC<DynamicChartsProps> = ({priceHistory, volumeHistory, orderBooks, quotes, isDarkTheme, initialSymbol}) => {
+    const [selectedSymbol, setSelectedSymbol] = useState<string>(initialSymbol || availableSymbols[0]);
+    const [chartType, setChartType] = useState<ChartType>("Price History");
+
+    const renderChart = () => {
+        switch (chartType) {
+            case "Price History":
+                return <PriceHistoryChart history={priceHistory[selectedSymbol] || []} isDarkTheme={isDarkTheme}/>;
+            case "Volume History":
+                return <VolumeHistoryChart history={volumeHistory[selectedSymbol] || []} isDarkTheme={isDarkTheme}/>;
+            case "Depth Chart":
+                return (
+                    <DepthChart
+                        selectedSymbolForDepthChart={selectedSymbol}
+                        isDarkTheme={isDarkTheme}
+                        closeDepthChartPopup={() => {}}
+                        trades={orderBooks[selectedSymbol] || []}
+                        midPrice={quotes[selectedSymbol]?.quote.c || 0}
+                    />
+                );
+            case "Moving Average":
+                return <MovingAverageChart history={priceHistory[selectedSymbol] || []} isDarkTheme={isDarkTheme}/>;
+            case "Price & Volume":
+                return (
+                    <PriceVolumeChart
+                        priceHistory={priceHistory[selectedSymbol] || []}
+                        volumeHistory={volumeHistory[selectedSymbol] || []}
+                        isDarkTheme={isDarkTheme}
+                    />
+                );
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <div className="w-full">
+            <div className="flex space-x-2 mb-2">
+                <select
+                    value={selectedSymbol}
+                    onChange={(e) => setSelectedSymbol(e.target.value)}
+                    className="p-1 text-black"
+                >
+                    {availableSymbols.map((s) => (
+                        <option key={s} value={s}>
+                            {s}
+                        </option>
+                    ))}
+                </select>
+                <select
+                    value={chartType}
+                    onChange={(e) => setChartType(e.target.value as ChartType)}
+                    className="p-1 text-black"
+                >
+                    {chartOptions.map((opt) => (
+                        <option key={opt} value={opt}>
+                            {opt}
+                        </option>
+                    ))}
+                </select>
+            </div>
+            <div className="h-80 w-full flex items-center justify-center">
+                {renderChart()}
+            </div>
+        </div>
+    );
+};
+
+export default DynamicCharts;

--- a/src/components/quote/MovingAverageChart.tsx
+++ b/src/components/quote/MovingAverageChart.tsx
@@ -1,0 +1,94 @@
+import React, {useMemo} from "react";
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+} from "chart.js";
+import {Line} from "react-chartjs-2";
+import {PricePoint} from "./PriceHistoryChart";
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend
+);
+
+interface MovingAverageChartProps {
+    history: PricePoint[];
+    windowSize?: number;
+    isDarkTheme: boolean;
+}
+
+const MovingAverageChart: React.FC<MovingAverageChartProps> = ({history, windowSize = 5, isDarkTheme}) => {
+    const chartData = useMemo(() => {
+        const labels = history.map((h) => new Date(h.t).toLocaleTimeString());
+        const prices = history.map((h) => h.p);
+        const movingAvg: number[] = [];
+        for (let i = 0; i < prices.length; i++) {
+            const start = Math.max(0, i - windowSize + 1);
+            const subset = prices.slice(start, i + 1);
+            const avg = subset.reduce((a, b) => a + b, 0) / subset.length;
+            movingAvg.push(avg);
+        }
+        return {
+            labels,
+            datasets: [
+                {
+                    label: "Price",
+                    data: prices,
+                    borderColor: "rgba(75,192,192,1)",
+                    backgroundColor: "rgba(75,192,192,0.2)",
+                    fill: false,
+                    tension: 0.1,
+                },
+                {
+                    label: `${windowSize}-Period SMA`,
+                    data: movingAvg,
+                    borderColor: "rgba(255,99,132,1)",
+                    backgroundColor: "rgba(255,99,132,0.2)",
+                    fill: false,
+                    tension: 0.1,
+                },
+            ],
+        };
+    }, [history, windowSize]);
+
+    const options = {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            x: {
+                ticks: {color: isDarkTheme ? "#fff" : "#000"},
+            },
+            y: {
+                ticks: {color: isDarkTheme ? "#fff" : "#000"},
+            },
+        },
+        plugins: {
+            legend: {
+                labels: {color: isDarkTheme ? "#fff" : "#000"},
+            },
+        },
+    } as const;
+
+    if (history.length === 0) {
+        return <div className="p-4">No data to display.</div>;
+    }
+
+    return (
+        <div className="h-80 w-full">
+            <Line data={chartData} options={options}/>
+        </div>
+    );
+};
+
+export default MovingAverageChart;

--- a/src/components/quote/PriceVolumeChart.tsx
+++ b/src/components/quote/PriceVolumeChart.tsx
@@ -1,0 +1,94 @@
+import React, {useMemo} from "react";
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    BarElement,
+    Title,
+    Tooltip,
+    Legend,
+} from "chart.js";
+import { Chart } from "react-chartjs-2";
+import {PricePoint} from "./PriceHistoryChart";
+import {VolumePoint} from "./VolumeHistoryChart";
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    BarElement,
+    Title,
+    Tooltip,
+    Legend
+);
+
+interface PriceVolumeChartProps {
+    priceHistory: PricePoint[];
+    volumeHistory: VolumePoint[];
+    isDarkTheme: boolean;
+}
+
+const PriceVolumeChart: React.FC<PriceVolumeChartProps> = ({priceHistory, volumeHistory, isDarkTheme}) => {
+    const chartData = useMemo(() => {
+        const labels = priceHistory.map((p) => new Date(p.t).toLocaleTimeString());
+        return {
+            labels,
+            datasets: [
+                {
+                    label: "Price",
+                    type: "line" as const,
+                    data: priceHistory.map((p) => p.p),
+                    borderColor: "rgba(75,192,192,1)",
+                    backgroundColor: "rgba(75,192,192,0.2)",
+                    yAxisID: 'y1',
+                },
+                {
+                    label: "Volume",
+                    type: "bar" as const,
+                    data: volumeHistory.map((v) => v.v),
+                    backgroundColor: "rgba(153,102,255,0.5)",
+                    yAxisID: 'y2',
+                },
+            ],
+        };
+    }, [priceHistory, volumeHistory]);
+
+    const options = {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+            x: {
+                ticks: {color: isDarkTheme ? '#fff' : '#000'},
+            },
+            y1: {
+                type: 'linear' as const,
+                position: 'left' as const,
+                ticks: {color: isDarkTheme ? '#fff' : '#000'},
+            },
+            y2: {
+                type: 'linear' as const,
+                position: 'right' as const,
+                grid: {drawOnChartArea: false},
+                ticks: {color: isDarkTheme ? '#fff' : '#000'},
+            },
+        },
+        plugins: {
+            legend: {labels: {color: isDarkTheme ? '#fff' : '#000'}},
+        },
+    } as const;
+
+    if (priceHistory.length === 0 || volumeHistory.length === 0) {
+        return <div className="p-4">No data to display.</div>;
+    }
+
+    return (
+        <div className="h-80 w-full">
+            <Chart type='bar' data={chartData} options={options} />
+        </div>
+    );
+};
+
+export default PriceVolumeChart;

--- a/src/components/quote/QuoteComponent.tsx
+++ b/src/components/quote/QuoteComponent.tsx
@@ -11,6 +11,7 @@ import DepthChart from "./DepthChartComponent";
 import CommonDialog from "../common/CommonDialog";
 import PriceHistoryChart from "./PriceHistoryChart";
 import VolumeHistoryChart from "./VolumeHistoryChart";
+import DynamicCharts from "./DynamicCharts";
 
 // --- Interfaces ---
 export interface FinnhubQuote {
@@ -378,11 +379,22 @@ const QuotesComponent: React.FC = () => {
         setSelectedSymbolForVolumeHistory(null);
     };
 
+    const [chartDashboardSymbol, setChartDashboardSymbol] = useState<string | null>(null);
+    const openChartDashboard = (symbol?: string) => {
+        setChartDashboardSymbol(symbol ?? null);
+        setIsChartDashboardOpen(true);
+    };
+    const closeChartDashboard = () => {
+        setIsChartDashboardOpen(false);
+        setChartDashboardSymbol(null);
+    };
+
     const isLoading = Object.keys(quotes).length === 0;
     const [isOrderBookOpen, setIsOrderBookOpen] = useState(false);
     const [isDepthChartOpen, setIsDepthChartOpen] = useState(false);
     const [isPriceHistoryOpen, setIsPriceHistoryOpen] = useState(false);
     const [isVolumeHistoryOpen, setIsVolumeHistoryOpen] = useState(false);
+    const [isChartDashboardOpen, setIsChartDashboardOpen] = useState(false);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -391,6 +403,7 @@ const QuotesComponent: React.FC = () => {
                 closeDepthChartPopup();
                 closePriceHistoryPopup();
                 closeVolumeHistoryPopup();
+                closeChartDashboard();
             }
         };
         window.addEventListener("keydown", handleKeyDown);
@@ -429,6 +442,13 @@ const QuotesComponent: React.FC = () => {
             ) {
                 closeVolumeHistoryPopup();
             }
+            if (
+                isChartDashboardOpen &&
+                event.target instanceof HTMLElement &&
+                !event.target.closest(".dynamic-charts-popup")
+            ) {
+                closeChartDashboard();
+            }
         };
         window.addEventListener("click", handleClickOutside);
         return () => {
@@ -439,6 +459,7 @@ const QuotesComponent: React.FC = () => {
         selectedSymbolForDepthChart,
         selectedSymbolForPriceHistory,
         selectedSymbolForVolumeHistory,
+        isChartDashboardOpen,
     ]);
 
     return (
@@ -494,6 +515,16 @@ const QuotesComponent: React.FC = () => {
                         {selectedSymbols.length === availableSymbols.length
                             ? "Deselect All"
                             : "Select All"}
+                    </button>
+                    <button
+                        style={{
+                            background: isDarkTheme ? "#20242c" : "#ECEFF1",
+                            color: isDarkTheme ? "#ECEFF1" : "#20242c",
+                        }}
+                        onClick={() => openChartDashboard()}
+                        className="mt-1 w-full rounded py-2 text-white"
+                    >
+                        Charts Dashboard
                     </button>
                 </CollapsableSection>
             </div>
@@ -586,6 +617,15 @@ const QuotesComponent: React.FC = () => {
                                         >
                                             Volume History
                                         </button>
+                                        <button
+                                            className="rounded bg-gray-700 py-1 px-2 text-sm text-white"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                openChartDashboard(symbol);
+                                            }}
+                                        >
+                                            Charts
+                                        </button>
                                     </div>
                                 </div>
                                 <small className="block mt-1">{formatTime(data.quote.t)}</small>
@@ -636,6 +676,23 @@ const QuotesComponent: React.FC = () => {
                     }
                     isDarkTheme={isDarkTheme}
                 />
+            </CommonDialog>
+
+            <CommonDialog
+                title="Charts Dashboard"
+                onClose={closeChartDashboard}
+                isOpen={isChartDashboardOpen}
+            >
+                <div className="dynamic-charts-popup">
+                    <DynamicCharts
+                        priceHistory={priceHistory}
+                        volumeHistory={volumeHistory}
+                        orderBooks={orderBooks}
+                        quotes={quotes}
+                        isDarkTheme={isDarkTheme}
+                        initialSymbol={chartDashboardSymbol || undefined}
+                    />
+                </div>
             </CommonDialog>
 
             <DepthChart


### PR DESCRIPTION
## Summary
- add new MovingAverageChart component
- create DynamicCharts selector to choose quote and chart type
- hook charts dashboard into QuoteComponent
- expose charts from available price and volume data
- add price and volume combo chart
- let charts dashboard open for specific symbol

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841d241be28832bbe9cd9af8e2fd5e1