### PR TITLE
Add blue theme and update light font

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ TypeScript. It includes various essential libraries and tools to kickstart your 
 
 - `npm start`: Start the development server.
 - `npm run build`: Build the application for production.
-- `npm test`: Run tests using the Vitest testing framework.
+- `npm test`: Run tests using the Vitest testing framework. Make sure to
+  install dependencies first with `npm install` or `yarn`.
 - `npm run eject`: Eject from Create React App for advanced configuration.
 
 ### Usage

--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
     <!-- Preload Google Fonts for better performance -->
     <link href="https://fonts.googleapis.com" rel="preconnect">
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"
-          rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
 
     <title>Norbert Pascu's Portfolio</title>
 </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, {lazy, Suspense, useCallback, useEffect, useState} from "react";
 import {useDispatch, useSelector} from "react-redux";
-import {setTheme} from "./store/reducers/appReducer";
+import {setTheme, ThemeType} from "./store/reducers/appReducer";
 import {RootState} from "./store/store";
 import {useSwipeable} from "react-swipeable";
 import Loading from "./pages/generic/Loading";
@@ -16,6 +16,7 @@ const Toaster = lazy(() => import("./components/common/Toaster"));
 
 const App: React.FC = () => {
     const dispatch = useDispatch();
+    const theme = useSelector((state: RootState) => state.app.theme);
     const darkTheme = useSelector((state: RootState) => state.app.isDarkTheme);
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
     const location = useLocation();
@@ -42,23 +43,26 @@ const App: React.FC = () => {
 
     // Load theme from localStorage, defaulting to dark mode if no value is saved
     useEffect(() => {
-        // If nothing is stored in localStorage, default to dark mode (true)
-        const savedThemeStr = localStorage.getItem("isDarkTheme");
-        const savedTheme = savedThemeStr === null ? true : savedThemeStr === "true";
-        if (savedTheme !== darkTheme) {
+        let savedTheme = 'dark' as ThemeType;
+        const savedThemeStr = localStorage.getItem('theme');
+        if (savedThemeStr) {
+            savedTheme = savedThemeStr as ThemeType;
+        } else {
+            const oldThemeStr = localStorage.getItem('isDarkTheme');
+            const oldTheme = oldThemeStr === null ? true : oldThemeStr === 'true';
+            savedTheme = oldTheme ? 'dark' : 'light';
+        }
+        if (savedTheme !== theme) {
             dispatch(setTheme(savedTheme));
         }
-        document.documentElement.setAttribute(
-            "data-theme",
-            savedTheme ? "dark" : "light"
-        );
-    }, [dispatch, darkTheme]);
+        document.documentElement.setAttribute('data-theme', savedTheme);
+    }, [dispatch, theme]);
 
     return (
         <div
             id="app"
             {...swipeHandlers} // Attach swipe gestures
-            className={`${darkTheme ? "dark" : "light"}-theme app select-none`}
+            className={`${theme}-theme app select-none`}
             style={{touchAction: "none"}} // Prevent system gestures like back swipe
         >
             {/* Top Bar */}

--- a/src/assets/styles/blueTheme.css
+++ b/src/assets/styles/blueTheme.css
@@ -1,0 +1,109 @@
+.blue-theme {
+    color: #ffffff;
+    background-color: #1e3a8a;
+    font-family: "Nunito", sans-serif;
+}
+
+.blue-theme table {
+    color: #ffffff;
+    background-color: #1e3a8a;
+    padding: 1em;
+}
+
+.blue-theme .footer {
+    color: #ffffff;
+    background-color: #1e3a8a;
+}
+
+.blue-theme ::-webkit-scrollbar-thumb {
+    background-color: #333333;
+    /* Scrollbar thumb color */
+    border-radius: 4px;
+}
+
+.blue-theme ::-webkit-scrollbar-thumb:hover {
+    background-color: #444444;
+    /* Hover color for scrollbar thumb */
+}
+
+.blue-theme ::-webkit-scrollbar {
+    width: 6px;
+    /* Scrollbar width */
+    background: #0c4a6e;
+    /* Scrollbar background color */
+}
+
+#siteseal {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    z-index: 1000;
+}
+
+.blue-theme #selected-photo {
+    border: 1px solid #ffffff;
+    background-color: #1e3a8a;
+}
+
+.blue-theme #photo-canvas-details {
+    background-color: #1e3a8a;
+    color: #ffffff;
+}
+
+.blue-theme #photo-canvas-details select {
+    background-color: #1e3a8a;
+    color: #ffffff;
+}
+
+.blue-theme #product-basket {
+    color: #1e3a8a;
+}
+
+.blue-theme .collapsable-section {
+    background-color: #172554;
+}
+
+.blue-theme .collapsable-section .collapsable-section-header {
+    background-color: #172554;
+}
+
+.blue-theme .collapsable-section .collapsable-section-body {
+    background-color: #172554;
+}
+
+.blue-theme .card {
+    background-color: #1e3a8a;
+    color: #ffffff;
+}
+
+.blue-theme game-card {
+    background-color: #172554;
+    color: #ffffff;
+}
+
+.blue-theme #github-profile-card {
+    background-color: #172554;
+    color: #ffffff;
+}
+
+.blue-theme #top-bar {
+    background-color: #172554;
+    color: #ffffff;
+}
+
+.blue-theme .tooltiptext {
+    visibility: hidden;
+    width: 120px;
+    background-color: #333333;
+    /* Dark background color for tooltip */
+    color: #ffffff;
+    /* White text color for tooltip */
+    text-align: center;
+    border-radius: 4px;
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+    top: 125%;
+    left: 50%;
+    transform: translateX(-50%);
+}

--- a/src/assets/styles/lightTheme.css
+++ b/src/assets/styles/lightTheme.css
@@ -1,7 +1,7 @@
 .light-theme {
     color: #333333;
     background-color: #ECEFF1;
-    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+    font-family: 'Open Sans', 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
 }
 
 .light-theme table {

--- a/src/components/app/TopBar.tsx
+++ b/src/components/app/TopBar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {useDispatch, useSelector} from "react-redux";
-import {setTheme} from "../../store/reducers/appReducer";
+import {setTheme, ThemeType} from "../../store/reducers/appReducer";
 import {RootState} from "../../store/store";
 import ToggleSvgDark from "../../assets/icons/ToggleSvgDark";
 import ToggleSvgLight from "../../assets/icons/ToggleSvgLight";
@@ -8,14 +8,17 @@ import DownloadCVButton from "../common/DownloadCVButton";
 import LanguageSelector from "./LanguageSelector";
 
 const TopBar = () => {
+    const theme = useSelector((state: RootState) => state.app.theme);
     const isDarkTheme = useSelector((state: RootState) => state.app.isDarkTheme);
     const dispatch = useDispatch();
 
     const changeTheme = () => {
-        const newTheme = !isDarkTheme ? "true" : "false";
-        document.documentElement.setAttribute("data-theme", newTheme);
-        dispatch(setTheme(!isDarkTheme));
-        localStorage.setItem("isDarkTheme", newTheme);
+        const themeOrder: ThemeType[] = ['dark', 'light', 'blue'];
+        const currentIndex = themeOrder.indexOf(theme);
+        const nextTheme = themeOrder[(currentIndex + 1) % themeOrder.length];
+        document.documentElement.setAttribute('data-theme', nextTheme);
+        dispatch(setTheme(nextTheme));
+        localStorage.setItem('theme', nextTheme);
     };
 
     return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import {HashRouter} from "react-router-dom";
 import store from "./store/store";
 import "./assets/styles/darkTheme.css";
 import "./assets/styles/lightTheme.css";
+import "./assets/styles/blueTheme.css";
 import "./assets/styles/snake.css";
 import "./assets/styles/topBar.css";
 

--- a/src/store/reducers/appReducer.ts
+++ b/src/store/reducers/appReducer.ts
@@ -1,6 +1,9 @@
 import {createSlice, PayloadAction} from '@reduxjs/toolkit';
 
+export type ThemeType = 'dark' | 'light' | 'blue';
+
 interface AppState {
+    theme: ThemeType;
     isDarkTheme: boolean;
     toaster: {
         showToaster: boolean;
@@ -12,6 +15,7 @@ interface AppState {
 }
 
 const initialState: AppState = {
+    theme: 'dark',
     isDarkTheme: true,
     toaster: {
         showToaster: false,
@@ -25,8 +29,9 @@ const appSlice = createSlice({
     name: 'app',
     initialState,
     reducers: {
-        setTheme: (state: AppState, action: PayloadAction<boolean>) => {
-            state.isDarkTheme = action.payload;
+        setTheme: (state: AppState, action: PayloadAction<ThemeType>) => {
+            state.theme = action.payload;
+            state.isDarkTheme = action.payload !== 'light';
         },
         setShowToaster: (state: AppState, action: PayloadAction<boolean>) => {
             state.toaster.showToaster = action.payload;


### PR DESCRIPTION
## Summary
- support multiple themes via string `theme` state
- cycle through `dark`, `light`, and new `blue` theme in the top bar
- add blue theme stylesheet and import it
- improve font in light theme with **Open Sans**
- preload Open Sans in `index.html`
- clarify README instructions for running tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d3bfce8c832b88875d535d9a9163