### PR TITLE
Fix depth chart modal interactions

### DIFF
--- a/src/components/quote/DepthChartComponent.tsx
+++ b/src/components/quote/DepthChartComponent.tsx
@@ -84,7 +84,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
             >
                 <div
                     onClick={(e) => e.stopPropagation()}
-                    className={`relative p-2 w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto ${
+                    className={`depth-chart-popup relative p-2 w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto ${
                         isDarkTheme ? "bg-gray-800 text-white" : "bg-white text-gray-900"
                     } rounded shadow-lg`}
                 >
@@ -299,7 +299,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
         >
             <div
                 onClick={(e) => e.stopPropagation()}
-                className={`relative p-2 w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto ${
+                className={`depth-chart-popup relative p-2 w-11/12 max-w-3xl max-h-[90vh] overflow-y-auto ${
                     isDarkTheme ? "bg-gray-800 text-white" : "bg-white text-gray-900"
                 } rounded shadow-lg`}
             >

--- a/src/components/quote/QuoteComponent.tsx
+++ b/src/components/quote/QuoteComponent.tsx
@@ -381,6 +381,8 @@ const QuotesComponent: React.FC = () => {
 
     const [chartDashboardSymbol, setChartDashboardSymbol] = useState<string | null>(null);
     const openChartDashboard = (symbol?: string) => {
+        // Ensure depth chart popup is closed when opening the dashboard
+        closeDepthChartPopup();
         setChartDashboardSymbol(symbol ?? null);
         setIsChartDashboardOpen(true);
     };


### PR DESCRIPTION
## Summary
- keep chart dashboard from opening under a depth chart popup
- mark depth chart popup container with `depth-chart-popup` class

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684496612cd0832b8f9a3e72dfa52841