### PR TITLE
Improve page transitions and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,12 @@
     <!-- Preload Google Fonts for better performance -->
     <link href="https://fonts.googleapis.com" rel="preconnect">
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript>
+        <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+    </noscript>
 
     <title>Norbert Pascu's Portfolio</title>
 </head>

--- a/src/assets/styles/index.css
+++ b/src/assets/styles/index.css
@@ -28,6 +28,14 @@ html {
     min-height: 100dvh;
 }
 
+body {
+    font-family: 'Open Sans', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: 'Nunito', sans-serif;
+}
+
 ::-webkit-scrollbar-thumb {
     border-radius: 2px;
     background-color: #8888;

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,8 +1,9 @@
 import React, {Suspense} from 'react';
-import {Route, Routes} from 'react-router-dom';
+import {Route, Routes, useLocation} from 'react-router-dom';
 import {routeDefinition} from './routeDefinition';
 import Loading from '../pages/generic/Loading';
 import {RouteDefinition} from '../models/common/common';
+import {AnimatePresence} from 'framer-motion';
 
 const renderRoutes = (routes: RouteDefinition[]) => {
     return routes.map((route: RouteDefinition, index) => (
@@ -17,12 +18,15 @@ const renderRoutes = (routes: RouteDefinition[]) => {
 };
 
 const RoutesSwitch = () => {
+    const location = useLocation();
     return (
-        <Suspense fallback={<Loading/>}>
-            <Routes>
-                {renderRoutes(routeDefinition)}
-            </Routes>
-        </Suspense>
+        <AnimatePresence mode="wait">
+            <Suspense fallback={<Loading/>}>
+                <Routes location={location} key={location.pathname}>
+                    {renderRoutes(routeDefinition)}
+                </Routes>
+            </Suspense>
+        </AnimatePresence>
     );
 };
 

--- a/src/router/routeDefinition.tsx
+++ b/src/router/routeDefinition.tsx
@@ -1,6 +1,7 @@
 import React, {lazy, Suspense} from "react";
 import {RouteDefinition} from "../models/common/common";
 import Loading from "../pages/generic/Loading";
+import {motion} from 'framer-motion';
 
 // Lazy load the page components
 const MainPage = lazy(() => import("../pages/MainPage"));
@@ -13,7 +14,14 @@ const AboutPage = lazy(() => import("../pages/AboutPage"));
 
 const withSuspense = (Component: React.LazyExoticComponent<React.ComponentType<any>>) => (
     <Suspense fallback={<Loading/>}>
-        <Component/>
+        <motion.div
+            initial={{opacity: 0, y: 10}}
+            animate={{opacity: 1, y: 0}}
+            exit={{opacity: 0, y: -10}}
+            transition={{duration: 0.2}}
+        >
+            <Component/>
+        </motion.div>
     </Suspense>
 );
 


### PR DESCRIPTION
## Summary
- preload fonts for faster loading
- set global fonts in styles
- add animated page transitions via framer-motion

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68469ec58168832bbc53c3727144b24a