### PR TITLE
Reduce layout shift by loading main page eagerly

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -17,10 +17,10 @@ import NewVTech from "../assets/icons/NewVTech";
 import {FaChartLine} from "react-icons/fa";
 import MavxIcon from "../assets/icons/MavXIcon";
 import {useTranslation} from "react-i18next";
+import GithubProfileCard from "../components/main-page/GithubProfileCard";
 
 // --- Lazy Imports ---
 const EducationCard = lazy(() => import("../components/main-page/EducationAndTraining"));
-const GithubProfileCard = lazy(() => import("../components/main-page/GithubProfileCard"));
 const YoutubeVideoLink = lazy(() => import("../components/main-page/YoutubeVideoLink"));
 const CollapsibleSection = lazy(() => import("../components/common/CollapsableSection"));
 const HighlightedRepos = lazy(() => import("../components/main-page/HighlightedRepos"));
@@ -106,9 +106,7 @@ const MainPage = () => {
             style={{height: "calc(100vh - 6rem)", overflow: "auto"}}
         >
             <div className="flex items-center justify-center">
-                <Suspense fallback={<Loading/>}>
-                    <GithubProfileCard/>
-                </Suspense>
+                <GithubProfileCard/>
             </div>
             {/* NEW: Live Quotes Section */}
             <Suspense fallback={<Loading/>}>

--- a/src/router/routeDefinition.tsx
+++ b/src/router/routeDefinition.tsx
@@ -4,7 +4,7 @@ import Loading from "../pages/generic/Loading";
 import {motion} from 'framer-motion';
 
 // Lazy load the page components
-const MainPage = lazy(() => import("../pages/MainPage"));
+import MainPage from "../pages/MainPage";
 const GamesCardPage = lazy(() => import("../pages/game/GamesContainer"));
 const QuotePage = lazy(() => import("../components/quote/QuoteComponent"));
 const DynamicComponentsContainerPage = lazy(() =>
@@ -29,7 +29,7 @@ export const routeDefinition: RouteDefinition[] = [
     {
         path: "*",
         exact: true,
-        element: withSuspense(MainPage),
+        element: <MainPage/>,
     },
     {
         path: "/games/*",


### PR DESCRIPTION
## Summary
- import GithubProfileCard directly and remove the Suspense wrapper
- load `MainPage` synchronously in the router so the home page doesn't flash the loading spinner

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c11a12c78832ba4004d19992d67e5