### PR TITLE
Add contact page and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ TypeScript. It includes various essential libraries and tools to kickstart your 
 This project is a great starting point for building modern web applications with a focus on React, Redux, and
 TypeScript. Feel free to customize and expand it to meet your specific project requirements.
 
+### New Features
+
+- **Contact Page**: Reach out directly using the new `/contact` route with a simple form that opens your mail client.
+
 ### Browser Support
 
 - **Production**: Targeting modern browsers with a global usage share of more than 0.2%.

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -228,5 +228,13 @@
     "profileDescription": "Full-Stack Engineer | Technikbegeisterter | Über 9 Jahre Erfahrung in Fintech, Einzelhandel, Automobil- und Chemieindustrie",
     "emailLabel": "norbipascu92@gmail.com",
     "phoneLabel": "+41765951562"
+  },
+  "contact": {
+    "title": "Kontakt",
+    "subtitle": "Interessiert an einer Zusammenarbeit? Schreib mir eine Nachricht!",
+    "name": "Name",
+    "email": "E-Mail",
+    "message": "Nachricht",
+    "send": "Senden"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -228,5 +228,13 @@
     "profileDescription": "Full-Stack Engineer | Tech Enthusiast | 9+ years of experience in Fintech, Retail, Automobile, and Chemical Industry",
     "emailLabel": "norbipascu92@gmail.com",
     "phoneLabel": "+41765951562"
+  },
+  "contact": {
+    "title": "Get in Touch",
+    "subtitle": "Interested in working together? Send me a message!",
+    "name": "Name",
+    "email": "Email",
+    "message": "Message",
+    "send": "Send"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -228,5 +228,13 @@
     "profileDescription": "Ingeniero Full-Stack | Entusiasta de la tecnología | Más de 9 años de experiencia en fintech, retail, automotriz e industria química",
     "emailLabel": "norbipascu92@gmail.com",
     "phoneLabel": "+41765951562"
+  },
+  "contact": {
+    "title": "Contacto",
+    "subtitle": "¿Interesado en trabajar juntos? ¡Envíame un mensaje!",
+    "name": "Nombre",
+    "email": "Correo electrónico",
+    "message": "Mensaje",
+    "send": "Enviar"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -228,5 +228,13 @@
     "profileDescription": "Ingénieur Full-Stack | Passionné de technologie | Plus de 9 ans d'expérience dans la fintech, le commerce de détail, l'automobile et l'industrie chimique",
     "emailLabel": "norbipascu92@gmail.com",
     "phoneLabel": "+41765951562"
+  },
+  "contact": {
+    "title": "Contact",
+    "subtitle": "Intéressé par une collaboration ? Envoyez-moi un message !",
+    "name": "Nom",
+    "email": "E-mail",
+    "message": "Message",
+    "send": "Envoyer"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -228,5 +228,13 @@
     "profileDescription": "Full-Stack Engineer | Appassionato di tecnologia | Oltre 9 anni di esperienza in Fintech, retail, automobilistico e industria chimica",
     "emailLabel": "norbipascu92@gmail.com",
     "phoneLabel": "+41765951562"
+  },
+  "contact": {
+    "title": "Contatto",
+    "subtitle": "Interessato a collaborare? Inviami un messaggio!",
+    "name": "Nome",
+    "email": "Email",
+    "message": "Messaggio",
+    "send": "Invia"
   }
 }

--- a/src/components/app/SideBar.tsx
+++ b/src/components/app/SideBar.tsx
@@ -97,6 +97,15 @@ const SideBar: React.FC<SideBarProps> = ({isDrawerOpen, closeSidebar}) => {
                                         ℹ️ About Me
                                     </Link>
                                 </li>
+                                <li>
+                                    <Link
+                                        to="/contact"
+                                        className="flex items-center text-lg  transition"
+                                        onClick={closeSidebar}
+                                    >
+                                        📬 Contact
+                                    </Link>
+                                </li>
                             </ul>
                         </nav>
                     </motion.div>

--- a/src/components/app/TopBar.tsx
+++ b/src/components/app/TopBar.tsx
@@ -6,6 +6,7 @@ import ToggleSvgDark from "../../assets/icons/ToggleSvgDark";
 import ToggleSvgLight from "../../assets/icons/ToggleSvgLight";
 import DownloadCVButton from "../common/DownloadCVButton";
 import LanguageSelector from "./LanguageSelector";
+import { Link } from "react-router-dom";
 
 const TopBar = () => {
     const theme = useSelector((state: RootState) => state.app.theme);
@@ -23,9 +24,14 @@ const TopBar = () => {
 
     return (
         <div id="top-bar" data-testid="top-bar-test" className="top-bar">
-            <div className="flex justify-between w-full">
-                <DownloadCVButton/>
-                <div className="top-bar-section w-full mr-3">
+            <div className="flex justify-between w-full items-center">
+                <div className="flex items-center gap-2">
+                    <DownloadCVButton/>
+                    <Link to="/contact" className="px-2 py-1 bg-green-800 text-white hover:bg-green-900 transition-colors rounded text-sm">
+                        Contact
+                    </Link>
+                </div>
+                <div className="top-bar-section w-full mr-3 flex items-center justify-end gap-2">
                     <LanguageSelector/>
                     <button name="toggle-theme" aria-label="Toggle theme" onClick={changeTheme}>
                         {isDarkTheme ? <ToggleSvgLight/> : <ToggleSvgDark/>}

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { RootState } from "../store/store";
+import { useTranslation } from "react-i18next";
+
+const ContactPage: React.FC = () => {
+    const { t } = useTranslation();
+    const isDarkTheme = useSelector((state: RootState) => state.app.isDarkTheme);
+    const [formData, setFormData] = useState({ name: "", email: "", message: "" });
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        const mailtoLink = `mailto:norbipascu92@gmail.com?subject=Portfolio%20Contact%20from%20${encodeURIComponent(
+            formData.name
+        )}&body=${encodeURIComponent(formData.message)}%0A%0A${formData.email}`;
+        window.location.href = mailtoLink;
+    };
+
+    return (
+        <div
+            style={{ height: "calc(100vh - 5.5rem)", overflow: "auto" }}
+            className={`flex items-center justify-center transition-colors ${
+                isDarkTheme ? "bg-gray-900 text-white" : "bg-gray-100 text-gray-900"
+            }`}
+        >
+            <form onSubmit={handleSubmit} className="w-full max-w-md space-y-4 p-4 shadow-xl bg-white dark:bg-gray-800">
+                <h2 className="text-2xl font-bold text-center">{t("contact.title")}</h2>
+                <p className="text-sm text-center mb-2">{t("contact.subtitle")}</p>
+                <input
+                    name="name"
+                    value={formData.name}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-2 border border-gray-300 rounded"
+                    placeholder={t("contact.name") || "Name"}
+                />
+                <input
+                    type="email"
+                    name="email"
+                    value={formData.email}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-2 border border-gray-300 rounded"
+                    placeholder={t("contact.email") || "Email"}
+                />
+                <textarea
+                    name="message"
+                    value={formData.message}
+                    onChange={handleChange}
+                    rows={4}
+                    required
+                    className="w-full p-2 border border-gray-300 rounded"
+                    placeholder={t("contact.message") || "Message"}
+                />
+                <button type="submit" className="w-full bg-green-800 text-white py-2 hover:bg-green-900 transition-colors">
+                    {t("contact.send")}
+                </button>
+            </form>
+        </div>
+    );
+};
+
+export default ContactPage;

--- a/src/router/routeDefinition.tsx
+++ b/src/router/routeDefinition.tsx
@@ -11,6 +11,7 @@ const DynamicComponentsContainerPage = lazy(() =>
     import("../pages/dynamic/DynamicComponentsContainerPage")
 );
 const AboutPage = lazy(() => import("../pages/AboutPage"));
+const ContactPage = lazy(() => import("../pages/ContactPage"));
 
 const withSuspense = (Component: React.LazyExoticComponent<React.ComponentType<any>>) => (
     <Suspense fallback={<Loading/>}>
@@ -45,6 +46,11 @@ export const routeDefinition: RouteDefinition[] = [
         path: "/dynamic-components",
         exact: true,
         element: withSuspense(DynamicComponentsContainerPage),
+    },
+    {
+        path: "/contact",
+        exact: true,
+        element: withSuspense(ContactPage),
     },
     {
         path: "/about",


### PR DESCRIPTION
## Summary
- create `ContactPage` with a simple form that launches an email
- expose the page via route definition
- link to the new page from the sidebar and top bar
- add translations for a new "contact" section in all locales
- mention the new contact page in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c7c9a0670832b9aa9e66a4847d587