### PR TITLE
Fix contact form translations and show email config error

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 VITE_API_KEY = http://localhost:5252/quotesHub
 VITE_EMAIL_API=
+# Example: https://example.com/api/send-email

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This project is a great starting point for building modern web applications with
 TypeScript. Feel free to customize and expand it to meet your specific project requirements.
 
 To enable the contact form's email sending feature, set the `VITE_EMAIL_API` environment variable to the URL of your email service.
+If this variable is left empty, the form will still render but no message will be sent.
 
 ### New Features
 

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -227,7 +227,11 @@
     "specialties": ".NET und React",
     "profileDescription": "Full-Stack Engineer | Technikbegeisterter | Über 9 Jahre Erfahrung in Fintech, Einzelhandel, Automobil- und Chemieindustrie",
     "emailLabel": "norbipascu92@gmail.com",
-    "phoneLabel": "+41765951562"
+  "phoneLabel": "+41765951562"
+  },
+  "navigation": {
+    "contact": "Kontakt",
+    "back": "Zurück"
   },
   "contact": {
     "title": "Kontakt",
@@ -238,6 +242,7 @@
     "send": "Senden",
     "invalidEmail": "Bitte eine gültige E-Mail-Adresse eingeben",
     "success": "Nachricht erfolgreich gesendet",
-    "error": "Fehler beim Senden der Nachricht"
+    "error": "Fehler beim Senden der Nachricht",
+    "serviceError": "E-Mail-Dienst nicht konfiguriert"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -227,7 +227,11 @@
     "specialties": ".NET and React",
     "profileDescription": "Full-Stack Engineer | Tech Enthusiast | 9+ years of experience in Fintech, Retail, Automobile, and Chemical Industry",
     "emailLabel": "norbipascu92@gmail.com",
-    "phoneLabel": "+41765951562"
+  "phoneLabel": "+41765951562"
+  },
+  "navigation": {
+    "contact": "Contact",
+    "back": "Back"
   },
   "contact": {
     "title": "Get in Touch",
@@ -238,6 +242,7 @@
     "send": "Send",
     "invalidEmail": "Please enter a valid email address",
     "success": "Message sent successfully",
-    "error": "Failed to send message"
+    "error": "Failed to send message",
+    "serviceError": "Email service not configured"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -227,7 +227,11 @@
     "specialties": ".NET y React",
     "profileDescription": "Ingeniero Full-Stack | Entusiasta de la tecnología | Más de 9 años de experiencia en fintech, retail, automotriz e industria química",
     "emailLabel": "norbipascu92@gmail.com",
-    "phoneLabel": "+41765951562"
+  "phoneLabel": "+41765951562"
+  },
+  "navigation": {
+    "contact": "Contacto",
+    "back": "Atrás"
   },
   "contact": {
     "title": "Contacto",
@@ -238,6 +242,7 @@
     "send": "Enviar",
     "invalidEmail": "Por favor ingresa un correo electrónico válido",
     "success": "Mensaje enviado exitosamente",
-    "error": "No se pudo enviar el mensaje"
+    "error": "No se pudo enviar el mensaje",
+    "serviceError": "Servicio de correo no configurado"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -227,7 +227,11 @@
     "specialties": ".NET et React",
     "profileDescription": "Ingénieur Full-Stack | Passionné de technologie | Plus de 9 ans d'expérience dans la fintech, le commerce de détail, l'automobile et l'industrie chimique",
     "emailLabel": "norbipascu92@gmail.com",
-    "phoneLabel": "+41765951562"
+  "phoneLabel": "+41765951562"
+  },
+  "navigation": {
+    "contact": "Contact",
+    "back": "Retour"
   },
   "contact": {
     "title": "Contact",
@@ -238,6 +242,7 @@
     "send": "Envoyer",
     "invalidEmail": "Veuillez saisir une adresse e-mail valide",
     "success": "Message envoyé avec succès",
-    "error": "Échec de l'envoi du message"
+    "error": "Échec de l'envoi du message",
+    "serviceError": "Service de messagerie non configuré"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -227,7 +227,11 @@
     "specialties": ".NET e React",
     "profileDescription": "Full-Stack Engineer | Appassionato di tecnologia | Oltre 9 anni di esperienza in Fintech, retail, automobilistico e industria chimica",
     "emailLabel": "norbipascu92@gmail.com",
-    "phoneLabel": "+41765951562"
+  "phoneLabel": "+41765951562"
+  },
+  "navigation": {
+    "contact": "Contatto",
+    "back": "Indietro"
   },
   "contact": {
     "title": "Contatto",
@@ -238,6 +242,7 @@
     "send": "Invia",
     "invalidEmail": "Inserisci un indirizzo email valido",
     "success": "Messaggio inviato con successo",
-    "error": "Invio del messaggio non riuscito"
+    "error": "Invio del messaggio non riuscito",
+    "serviceError": "Servizio email non configurato"
   }
 }

--- a/src/components/app/TopBar.tsx
+++ b/src/components/app/TopBar.tsx
@@ -7,10 +7,12 @@ import ToggleSvgLight from "../../assets/icons/ToggleSvgLight";
 import DownloadCVButton from "../common/DownloadCVButton";
 import LanguageSelector from "./LanguageSelector";
 import { Link, useLocation } from "react-router-dom";
+import {useTranslation} from "react-i18next";
 
 const TopBar = () => {
     const theme = useSelector((state: RootState) => state.app.theme);
     const isDarkTheme = useSelector((state: RootState) => state.app.isDarkTheme);
+    const {t} = useTranslation();
     const dispatch = useDispatch();
     const location = useLocation();
 
@@ -32,14 +34,14 @@ const TopBar = () => {
                         to="/"
                         className="inline-flex items-center px-2 py-1 bg-green-800 text-white hover:bg-green-900 border border-gray-600 transition-colors duration-300 ease-in-out"
                     >
-                        Back
+                        {t('navigation.back')}
                     </Link>
                 ) : (
                     <Link
                         to="/contact"
                         className="inline-flex items-center px-2 py-1 bg-green-800 text-white hover:bg-green-900 border border-gray-600 transition-colors duration-300 ease-in-out"
                     >
-                        Contact
+                        {t('navigation.contact')}
                     </Link>
                 )}
             </div>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -33,8 +33,12 @@ const ContactPage: React.FC = () => {
             dispatch(setToasterMessage(t("contact.success")));
             dispatch(setShowToaster(true));
             setFormData({ name: "", email: "", message: "" });
-        } catch (err) {
-            dispatch(setToasterMessage(t("contact.error")));
+        } catch (err: any) {
+            if (typeof err === 'string' && err.includes('not configured')) {
+                dispatch(setToasterMessage(t('contact.serviceError')));
+            } else {
+                dispatch(setToasterMessage(t('contact.error')));
+            }
             dispatch(setShowToaster(true));
         }
     };


### PR DESCRIPTION
## Summary
- improve wording in README about the `VITE_EMAIL_API` variable
- add placeholder comment in `.env`
- translate `Contact` and `Back` buttons
- show a clear error when the email service isn't configured
- add navigation translations for all languages

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684c8a6114d8832b9e1f6e87ec31bc2f