### PR TITLE
Switch sample screens to image grid

### DIFF
--- a/src/components/common/ImageGrid.tsx
+++ b/src/components/common/ImageGrid.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import LazyImage from "./LazyImage";
+import useFullScreenToggle from "../../hooks/useToggleFullscreen";
+const FullScreenImage = React.lazy(() => import("./FullScreenImage"));
+
+interface ImageGridProps {
+    images: string[];
+}
+
+const ImageGrid = ({ images }: ImageGridProps) => {
+    const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+    const { isFullScreen, toggleFullScreen } = useFullScreenToggle();
+
+    const openImage = (index: number) => {
+        setCurrentIndex(index);
+        toggleFullScreen();
+    };
+
+    const closeImage = () => {
+        toggleFullScreen();
+        setCurrentIndex(null);
+    };
+
+    const handlePrev = () => {
+        if (currentIndex === null) return;
+        setCurrentIndex((prev) => (prev! > 0 ? prev! - 1 : images.length - 1));
+    };
+
+    const handleNext = () => {
+        if (currentIndex === null) return;
+        setCurrentIndex((prev) => (prev! < images.length - 1 ? prev! + 1 : 0));
+    };
+
+    return (
+        <div>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+                {images.map((img, idx) => (
+                    <div
+                        key={idx}
+                        className="cursor-pointer"
+                        onClick={() => openImage(idx)}
+                    >
+                        <LazyImage
+                            src={img}
+                            alt={`${idx}`}
+                            className="object-cover w-full h-40"
+                        />
+                    </div>
+                ))}
+            </div>
+            {isFullScreen && currentIndex !== null && (
+                <FullScreenImage
+                    handlePrevClick={handlePrev}
+                    handleNextClick={handleNext}
+                    toggleFullScreen={closeImage}
+                    selectedImage={images[currentIndex]}
+                />
+            )}
+        </div>
+    );
+};
+
+export default React.memo(ImageGrid);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -24,7 +24,7 @@ const EducationCard = lazy(() => import("../components/main-page/EducationAndTra
 const YoutubeVideoLink = lazy(() => import("../components/main-page/YoutubeVideoLink"));
 const CollapsibleSection = lazy(() => import("../components/common/CollapsableSection"));
 const HighlightedRepos = lazy(() => import("../components/main-page/HighlightedRepos"));
-const ImageSlider = lazy(() => import("../components/common/ImageSlider"));
+const ImageGrid = lazy(() => import("../components/common/ImageGrid"));
 
 const AmarisCard = lazy(() =>
     import("../components/main-page/ExperienceCards").then((mod) => ({
@@ -310,7 +310,7 @@ const MainPage = () => {
                     <CollapsibleSection title={t("sampleScreens")}>
                         {!!workImages?.length && (
                             <Suspense fallback={<Loading/>}>
-                                <ImageSlider images={workImages}/>
+                                <ImageGrid images={workImages}/>
                             </Suspense>
                         )}
                     </CollapsibleSection>


### PR DESCRIPTION
## Summary
- add `ImageGrid` component for viewing thumbnails in a grid with fullscreen view
- switch sample screen section on MainPage to use ImageGrid

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_685bcef8754c832bb5d2ba21236d4197