### PR TITLE
test: gate deploy on tests and expand coverage

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -6,9 +6,28 @@ on:
 
 name: 🚀 Deploy website on push
 jobs:
+  test:
+    name: ✅ Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install packages
+        run: yarn install
+
+      - name: Run tests
+        run: yarn test
+
   web-deploy:
     name: 🎉 Deploy
     runs-on: ubuntu-latest
+    needs: test
 
     steps:
 
@@ -18,7 +37,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package.lock') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install packages
         run: yarn install

--- a/src/__tests__/hooks/useDebounced.test.tsx
+++ b/src/__tests__/hooks/useDebounced.test.tsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+
+import React, { act } from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { useDebounced } from '../../hooks/useDebounceHook';
+
+function TestComponent({ value, delay }: { value: string; delay: number }) {
+  const debounced = useDebounced(value, delay);
+  return <div data-testid="value">{debounced}</div>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('useDebounced hook', () => {
+  it('updates the value only after the specified delay', () => {
+    vi.useFakeTimers();
+    // enable act in React 19 environment
+    // @ts-ignore
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    const { rerender } = render(<TestComponent value="a" delay={500} />);
+    expect(screen.getByTestId('value').textContent).toBe('a');
+
+    rerender(<TestComponent value="b" delay={500} />);
+    // value should remain 'a' before timers run
+    expect(screen.getByTestId('value').textContent).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId('value').textContent).toBe('b');
+  });
+
+  it('updates when the initial value changes after mount', () => {
+    vi.useFakeTimers();
+    // enable act in React 19 environment
+    // @ts-ignore
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    const { rerender } = render(<TestComponent value="first" delay={400} />);
+    expect(screen.getByTestId('value').textContent).toBe('first');
+
+    // change the initial prop value on rerender
+    rerender(<TestComponent value="second" delay={400} />);
+    // debounced value should not update immediately
+    expect(screen.getByTestId('value').textContent).toBe('first');
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByTestId('value').textContent).toBe('second');
+  });
+
+  it('updates to the latest value after rapid changes', () => {
+    vi.useFakeTimers();
+    // enable act in React 19 environment
+    // @ts-ignore
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    const { rerender } = render(<TestComponent value="a" delay={500} />);
+    expect(screen.getByTestId('value').textContent).toBe('a');
+
+    rerender(<TestComponent value="b" delay={500} />);
+    rerender(<TestComponent value="c" delay={500} />);
+
+    // value should remain 'a' before timers run
+    expect(screen.getByTestId('value').textContent).toBe('a');
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByTestId('value').textContent).toBe('c');
+  });
+
+  it('clears pending timers on unmount and delay change', () => {
+    vi.useFakeTimers();
+    // enable act in React 19 environment
+    // @ts-ignore
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+    const first = render(<TestComponent value="a" delay={500} />);
+    // one timer scheduled
+    expect(vi.getTimerCount()).toBe(1);
+
+    // unmount should clear timer
+    first.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // render again to test delay change
+    const second = render(<TestComponent value="a" delay={500} />);
+    expect(vi.getTimerCount()).toBe(1);
+
+    second.rerender(<TestComponent value="a" delay={1000} />);
+    // there should still be only one timer after delay change
+    expect(vi.getTimerCount()).toBe(1);
+
+    second.unmount();
+  });
+});

--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -23,6 +23,10 @@ describe('dateFormater', () => {
     const iso = '2024-01-02T03:04:00.000Z';
     expect(dateFormater(iso)).toBe('2024-01-02 03:04');
   });
+
+  it('returns N/A when date is empty', () => {
+    expect(dateFormater('')).toBe('N/A');
+  });
 });
 
   describe('parseCSV', () => {

--- a/src/hooks/useDebounceHook.ts
+++ b/src/hooks/useDebounceHook.ts
@@ -1,5 +1,11 @@
 import {useEffect, useState} from "react";
 
+/**
+ * Returns a debounced version of `value` that only updates after `delay`.
+ *
+ * Any pending timer is cleared when the hook unmounts or when either `value`
+ * or `delay` change, ensuring that no orphaned timeouts remain.
+ */
 export const useDebounced = <T>(value: T, delay: number): T => {
     const [debouncedValue, setDebouncedValue] = useState(value);
 


### PR DESCRIPTION
## Summary
- add dedicated job running vitest before deploy
- test useDebounced hook debounce behavior including rapid updates, initial prop changes and timer cleanup
- cover empty input case for dateFormater
- document timer cleanup semantics in useDebounced hook
- cache yarn dependencies using yarn.lock

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6897c866006c832bb489d88aedd54557