### PR TITLE
fix: grant actions read permissions for deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,9 @@ jobs:
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
 
     steps:
       - name: Download build artifact


### PR DESCRIPTION
## Summary
- ensure deploy workflow can download build artifact by adding actions read permissions

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_689878e07c28832b9ed4c339bf0c77cb