### PR TITLE
fix: ensure build artifact is available for deploy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,3 +34,4 @@ jobs:
         with:
           name: build
           path: build
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jsdom": "^24.0.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.3.3",
+    "terser": "^5.43.1",
     "typescript": "^5.0.4",
     "vite": "^5.2.6",
     "vite-plugin-compression": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7670,6 +7670,7 @@ __metadata:
     react-swipeable: "npm:^7.0.2"
     react-tailwindcss-datepicker: "npm:^2.0.0"
     tailwindcss: "npm:^3.3.3"
+    terser: "npm:^5.43.1"
     typescript: "npm:^5.0.4"
     vite: "npm:^5.2.6"
     vite-plugin-compression: "npm:^0.5.1"
@@ -9967,6 +9968,20 @@ __metadata:
   bin:
     terser: bin/terser
   checksum: 10c0/f89d5f8c9ccfcd4f6e9a0ecd9569677e2784a876b5cd916e4bc3d19e057ddae3416391df8e40746b29285bdafd48bb3a4230df1453ad8ec8caa7dd67f48f6dc0
+  languageName: node
+  linkType: hard
+
+"terser@npm:^5.43.1":
+  version: 5.43.1
+  resolution: "terser@npm:5.43.1"
+  dependencies:
+    "@jridgewell/source-map": "npm:^0.3.3"
+    acorn: "npm:^8.14.0"
+    commander: "npm:^2.20.0"
+    source-map-support: "npm:~0.5.20"
+  bin:
+    terser: bin/terser
+  checksum: 10c0/9cd3fa09ea6bcb79eb71995216b8bef0651b18c5c3877535fc699a77e1ab43b140a4da5811ac9baeb654fa9ec939b17324092f0f0bdb19c402e101e3db946986
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- install terser to satisfy Vite's minify requirement
- fail the build workflow if build artifacts are missing

## Testing
- `yarn build-production`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68987a9eb2cc832ba7e1de6e313f135a