### PR TITLE
fix: add trailing slash to local build directory

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,6 @@ jobs:
           username: ${{ secrets.ftp_username_1 }}
           password: ${{ secrets.ftp_password_1 }}
           port: 21
-          local-dir: build
+          local-dir: build/
           server-dir: /public_html/
           timeout: 60000


### PR DESCRIPTION
## Summary
- ensure FTP deploy action's `local-dir` points to folder by appending trailing slash

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6898817d72b0832bbac01ca25910408f