### PR TITLE
fix: ensure build directory downloaded in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,6 +21,7 @@ jobs:
           name: build
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: build
 
       - name: "📂 Sync files pascu.io"
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5


### PR DESCRIPTION
## Summary
- ensure deploy workflow extracts artifact into `build` directory

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68988c1140a0832b9350d8178e77dd2c