### PR TITLE
Add market and tax API services with SignalR clients

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+VITE_API_BASE_URL = http://localhost:5252
 VITE_API_KEY = http://localhost:5252/quotesHub
 VITE_EMAIL_API=
 # Example: https://example.com/api/send-email

--- a/src/models/market.ts
+++ b/src/models/market.ts
@@ -1,0 +1,35 @@
+export interface FinnhubOrderBookDto {
+    symbol: string;
+    bids: [number, number][]; // [price, volume]
+    asks: [number, number][]; // [price, volume]
+}
+
+export interface FinnhubQuoteDto {
+    c: number; // current price
+    h: number; // high price of the day
+    l: number; // low price of the day
+    o: number; // open price of the day
+    pc: number; // previous close price
+    t: number; // timestamp
+}
+
+export interface FinnhubTradeDto {
+    p: number; // price
+    s: string; // symbol
+    t: number; // timestamp
+    v: number; // volume
+    c?: number | null;
+    side?: "bid" | "ask";
+}
+
+export interface DeductionEstimateResponse {
+    taxableIncome: number;
+    totalTax: number;
+    breakdown: Record<string, number>;
+}
+
+export interface AllowanceDto {
+    canton: string;
+    year: number;
+    [key: string]: number | string;
+}

--- a/src/services/ApiClient.ts
+++ b/src/services/ApiClient.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+class ApiClient {
+  private client: AxiosInstance;
+
+  constructor(baseURL: string = '') {
+    this.client = axios.create({
+      baseURL,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  public async get<T>(url: string, params?: Record<string, any>, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.get<T>(url, { params, ...config });
+    return response.data;
+  }
+
+  public async post<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.post<T>(url, data, config);
+    return response.data;
+  }
+
+  public async put<T>(url: string, data?: any, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.put<T>(url, data, config);
+    return response.data;
+  }
+
+  public async delete<T>(url: string, config?: AxiosRequestConfig): Promise<T> {
+    const response = await this.client.delete<T>(url, config);
+    return response.data;
+  }
+}
+
+export const apiClient = new ApiClient(import.meta.env.VITE_API_BASE_URL);
+export default ApiClient;

--- a/src/services/MarketService.ts
+++ b/src/services/MarketService.ts
@@ -1,0 +1,31 @@
+import { apiClient } from './ApiClient';
+import { FinnhubOrderBookDto, FinnhubQuoteDto, FinnhubTradeDto } from '../models/market';
+
+class MarketService {
+  getOrderBook(symbol: string, depth?: number) {
+    return apiClient.get<FinnhubOrderBookDto>(`/api/OrderBook/${symbol}`, { depth });
+  }
+
+  getQuotes() {
+    return apiClient.get<Record<string, FinnhubQuoteDto>>('/api/Quotes');
+  }
+
+  getQuote(symbol: string) {
+    return apiClient.get<FinnhubQuoteDto>(`/api/Quotes/${symbol}`);
+  }
+
+  getSnapshot(symbol: string) {
+    return apiClient.get<FinnhubQuoteDto>(`/api/Snapshot/${symbol}`);
+  }
+
+  getTrades(symbol: string, from: string, to: string, limit?: number) {
+    return apiClient.get<FinnhubTradeDto[]>(`/api/Trades/${symbol}`, { from, to, limit });
+  }
+
+  healthCheck() {
+    return apiClient.get<{ status: string }>('/health');
+  }
+}
+
+export const marketService = new MarketService();
+export default MarketService;

--- a/src/services/SignalRService.ts
+++ b/src/services/SignalRService.ts
@@ -1,0 +1,36 @@
+import * as signalR from '@microsoft/signalr';
+import { FinnhubQuoteDto } from '../models/market';
+
+const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+
+export const connectQuotesHub = (
+  onQuote: (symbol: string, quote: FinnhubQuoteDto) => void
+) => {
+  const connection = new signalR.HubConnectionBuilder()
+    .withUrl(`${baseUrl}/quotesHub`)
+    .withAutomaticReconnect()
+    .build();
+
+  connection.on('ReceiveQuote', onQuote);
+  return connection.start().then(() => connection);
+};
+
+export const connectMarketHub = (
+  onUpdate: (symbol: string, data: unknown) => void
+) => {
+  const connection = new signalR.HubConnectionBuilder()
+    .withUrl(`${baseUrl}/hubs/market`)
+    .withAutomaticReconnect()
+    .build();
+
+  connection.on('MarketUpdate', onUpdate);
+  return connection.start().then(() => connection);
+};
+
+export const subscribe = (connection: signalR.HubConnection, symbol: string) => {
+  return connection.invoke('Subscribe', symbol);
+};
+
+export const unsubscribe = (connection: signalR.HubConnection, symbol: string) => {
+  return connection.invoke('Unsubscribe', symbol);
+};

--- a/src/services/TaxService.ts
+++ b/src/services/TaxService.ts
@@ -1,0 +1,22 @@
+import { apiClient } from './ApiClient';
+import { DeductionEstimateResponse, AllowanceDto } from '../models/market';
+
+export interface DeductionEstimateRequest {
+  canton: string;
+  year: number;
+  grossIncome: number;
+  pillar3aContributions: number;
+}
+
+class TaxService {
+  estimateDeductions(request: DeductionEstimateRequest) {
+    return apiClient.post<DeductionEstimateResponse>('/v1/deductions/estimate', request);
+  }
+
+  getAllowances(canton: string, year: number) {
+    return apiClient.get<AllowanceDto>(`/v1/allowances/${canton}/${year}`);
+  }
+}
+
+export const taxService = new TaxService();
+export default TaxService;


### PR DESCRIPTION
## Summary
- define DTO models for quotes, order books, trades and tax responses
- centralize REST calls through an axios API client
- expose market, tax and SignalR services for all backend endpoints and hubs

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6898b7135364832b9567b1bc78f71338