### PR TITLE
Fix SignalR hub URLs to prevent duplicate path segments

### DIFF
--- a/src/components/quote/QuoteComponent.tsx
+++ b/src/components/quote/QuoteComponent.tsx
@@ -153,8 +153,9 @@ const QuotesComponent: React.FC = () => {
 
     useEffect(() => {
         // 1) Setup the SignalR connection
+        const quotesHubUrl = new URL('quotesHub', API_BASE_URL).toString();
         const connection = new signalR.HubConnectionBuilder()
-            .withUrl(`${API_BASE_URL}/quotesHub`)
+            .withUrl(quotesHubUrl)
             .withAutomaticReconnect({
                 nextRetryDelayInMilliseconds: (context) => {
                     // If we hit a rate limit, wait longer before reconnecting

--- a/src/services/SignalRService.ts
+++ b/src/services/SignalRService.ts
@@ -5,8 +5,9 @@ import { API_BASE_URL } from '../config';
 export const connectQuotesHub = (
   onQuote: (symbol: string, quote: FinnhubQuoteDto) => void
 ) => {
+  const quotesHubUrl = new URL('quotesHub', API_BASE_URL).toString();
   const connection = new signalR.HubConnectionBuilder()
-    .withUrl(`${API_BASE_URL}/quotesHub`)
+    .withUrl(quotesHubUrl)
     .withAutomaticReconnect()
     .build();
 
@@ -17,8 +18,9 @@ export const connectQuotesHub = (
 export const connectMarketHub = (
   onUpdate: (symbol: string, data: unknown) => void
 ) => {
+  const marketHubUrl = new URL('hubs/market', API_BASE_URL).toString();
   const connection = new signalR.HubConnectionBuilder()
-    .withUrl(`${API_BASE_URL}/hubs/market`)
+    .withUrl(marketHubUrl)
     .withAutomaticReconnect()
     .build();
 


### PR DESCRIPTION
## Summary
- Join SignalR hub paths with `new URL` to avoid `/quotesHub/quotesHub` duplications
- Use URL-based path joining in quote component for consistent hub connections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b3932b9bc832bafc903a0d1954634